### PR TITLE
API provides functionality for authenticated user to join event

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,4 +21,4 @@ Things you may want to cover:
 
 * Deployment instructions
 
-* ...
+* ... Checking

--- a/app/controllers/api/events_controller.rb
+++ b/app/controllers/api/events_controller.rb
@@ -1,5 +1,5 @@
 class Api::EventsController < ApplicationController
-  before_action :authenticate_user!, only: %i[create]
+  before_action :authenticate_user!, only: %i[create update]
 
   def index
     collection_events = Event.all
@@ -24,6 +24,12 @@ class Api::EventsController < ApplicationController
     else
       render json: { message: 'Event was NOT created.' }, status: 422
     end
+  end
+
+  def update
+    event = Event.where(id: params[:id]).first
+    event.attendees.create(user: current_user)
+    render json: { message: 'You are on the guest list!'}
   end
 
   private

--- a/app/controllers/api/events_controller.rb
+++ b/app/controllers/api/events_controller.rb
@@ -1,5 +1,6 @@
 class Api::EventsController < ApplicationController
-  before_action :authenticate
+  before_action :authenticate_user!, only: %i[create]
+
   def index
     collection_events = Event.all
     if collection_events.empty?
@@ -16,7 +17,7 @@ class Api::EventsController < ApplicationController
 
 
   def create
-    event = Event.create(event_params)
+    event = current_user.events.create(event_params)
 
     if event.persisted?
       render json: { message: 'Event was successfully created!' }, status: 200

--- a/app/controllers/api/events_controller.rb
+++ b/app/controllers/api/events_controller.rb
@@ -10,15 +10,9 @@ class Api::EventsController < ApplicationController
    end
   end
 
-  def show
-    event = Event.find(params[:id])
-    render json: event, serializer: EventListSerializer, status: 200
-  end
-
-
   def create
     event = current_user.events.create(event_params)
-
+    
     if event.persisted?
       render json: { message: 'Event was successfully created!' }, status: 200
     else
@@ -28,10 +22,10 @@ class Api::EventsController < ApplicationController
 
   def update
     event = Event.find(id: params[:id])
-    if event.attendee_limit >= event.attendees.count + 1 
+    if event.attendee_limit >= event.attendees.count + 1
       event.attendees.create(user: current_user)
-      render json: { message: 'You are on the guest list!'}, status: 200
-    else
+      render json: {message: 'You are on the guest list!'}
+    else 
       render json: { error_message: 'Guest list is full...' }, status: 400
     end
   end

--- a/app/controllers/api/events_controller.rb
+++ b/app/controllers/api/events_controller.rb
@@ -11,7 +11,7 @@ class Api::EventsController < ApplicationController
   end
 
   def create
-    event = current_user.events.create(event_params)
+    event = Event.create(event_params)
     if event.persisted?
       render json: { message: 'Event was successfully created!' }, status: 200
     else
@@ -32,6 +32,6 @@ class Api::EventsController < ApplicationController
   private
 
   def event_params
-    params.require(:event).permit(:title, :description, :category)
+    params.require(:event).permit(:title, :description, :category, :user_id, :attendee_limit)
   end
 end

--- a/app/controllers/api/events_controller.rb
+++ b/app/controllers/api/events_controller.rb
@@ -27,9 +27,13 @@ class Api::EventsController < ApplicationController
   end
 
   def update
-    event = Event.where(id: params[:id]).first
-    event.attendees.create(user: current_user)
-    render json: { message: 'You are on the guest list!'}
+    event = Event.find(id: params[:id])
+    if event.attendee_limit >= event.attendees.count + 1 
+      event.attendees.create(user: current_user)
+      render json: { message: 'You are on the guest list!'}, status: 200
+    else
+      render json: { error_message: 'Guest list is full...' }, status: 400
+    end
   end
 
   private

--- a/app/controllers/api/events_controller.rb
+++ b/app/controllers/api/events_controller.rb
@@ -7,7 +7,7 @@ class Api::EventsController < ApplicationController
       render json: { message: 'No events present' }, status: 404
     else
       render json: {events: collection_events}, status: 200
-   end
+    end
   end
 
   def create

--- a/app/controllers/api/events_controller.rb
+++ b/app/controllers/api/events_controller.rb
@@ -12,7 +12,6 @@ class Api::EventsController < ApplicationController
 
   def create
     event = current_user.events.create(event_params)
-    
     if event.persisted?
       render json: { message: 'Event was successfully created!' }, status: 200
     else

--- a/app/controllers/api/events_controller.rb
+++ b/app/controllers/api/events_controller.rb
@@ -11,7 +11,7 @@ class Api::EventsController < ApplicationController
   end
 
   def create
-    event = Event.create(event_params)
+    event = current_user.events.create(event_params)
     if event.persisted?
       render json: { message: 'Event was successfully created!' }, status: 200
     else
@@ -20,7 +20,7 @@ class Api::EventsController < ApplicationController
   end
 
   def update
-    event = Event.find(id: params[:id])
+    event = Event.find(params[:id])
     if event.attendee_limit >= event.attendees.count + 1
       event.attendees.create(user: current_user)
       render json: {message: 'You are on the guest list!'}

--- a/app/controllers/api/events_controller.rb
+++ b/app/controllers/api/events_controller.rb
@@ -1,4 +1,5 @@
 class Api::EventsController < ApplicationController
+  before_action :authenticate
   def index
     collection_events = Event.all
     if collection_events.empty?

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,3 +1,12 @@
 class ApplicationController < ActionController::API
   include DeviseTokenAuth::Concerns::SetUserByToken
+  rescue_from ActiveRecord::RecordNotFound, with: :render_active_record_error
+
+  private
+
+  def render_active_record_error(error)
+    render json: {
+      error_message: "We are experiencing internal errors. Please refresh the page and contact support. #{error.message}" 
+    }, status: 400
+  end
 end

--- a/app/models/attendee.rb
+++ b/app/models/attendee.rb
@@ -1,0 +1,4 @@
+class Attendee < ApplicationRecord
+  belongs_to :user
+  belongs_to :event
+end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -1,5 +1,5 @@
 class Event < ApplicationRecord
-  validates_presence_of :title, :description, :category
+  validates_presence_of :title, :description, :category, :attendee_limit
   enum category: [ :outdoors, :sports, :food, :games, :casual ]
   belongs_to :user
   has_many :attendees

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -1,4 +1,5 @@
 class Event < ApplicationRecord
   validates_presence_of :title, :description, :category
   enum category: [ :outdoors, :sports, :food, :games, :casual ]
+  belongs_to :user
 end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -2,4 +2,5 @@ class Event < ApplicationRecord
   validates_presence_of :title, :description, :category
   enum category: [ :outdoors, :sports, :food, :games, :casual ]
   belongs_to :user
+  has_many :attendees
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class User < ActiveRecord::Base
+  extend Devise::Models
+  # Include default devise modules. Others available are:
+  # :confirmable, :lockable, :timeoutable and :omniauthable
+  devise :database_authenticatable, :registerable,
+         :recoverable, :rememberable, :trackable, :validatable
+  include DeviseTokenAuth::Concerns::User
+  
+  has_many :events
+end

--- a/config/initializers/devise_token_auth.rb
+++ b/config/initializers/devise_token_auth.rb
@@ -1,5 +1,55 @@
+# frozen_string_literal: true
+
 DeviseTokenAuth.setup do |config|
-  config.change_headers_on_each_request = false
-  config.token_lifespan = 2.weeks
-  config.batch_request_buffer_throttle = 5.seconds
+  # By default the authorization headers will change after each request. The
+  # client is responsible for keeping track of the changing tokens. Change
+  # this to false to prevent the Authorization header from changing after
+  # each request.
+  # config.change_headers_on_each_request = true
+
+  # By default, users will need to re-authenticate after 2 weeks. This setting
+  # determines how long tokens will remain valid after they are issued.
+  # config.token_lifespan = 2.weeks
+
+  # Limiting the token_cost to just 4 in testing will increase the performance of
+  # your test suite dramatically. The possible cost value is within range from 4
+  # to 31. It is recommended to not use a value more than 10 in other environments.
+  config.token_cost = Rails.env.test? ? 4 : 10
+
+  # Sets the max number of concurrent devices per user, which is 10 by default.
+  # After this limit is reached, the oldest tokens will be removed.
+  # config.max_number_of_devices = 10
+
+  # Sometimes it's necessary to make several requests to the API at the same
+  # time. In this case, each request in the batch will need to share the same
+  # auth token. This setting determines how far apart the requests can be while
+  # still using the same auth token.
+  # config.batch_request_buffer_throttle = 5.seconds
+
+  # This route will be the prefix for all oauth2 redirect callbacks. For
+  # example, using the default '/omniauth', the github oauth2 provider will
+  # redirect successful authentications to '/omniauth/github/callback'
+  # config.omniauth_prefix = "/omniauth"
+
+  # By default sending current password is not needed for the password update.
+  # Uncomment to enforce current_password param to be checked before all
+  # attribute updates. Set it to :password if you want it to be checked only if
+  # password is updated.
+  # config.check_current_password_before_update = :attributes
+
+  # By default we will use callbacks for single omniauth.
+  # It depends on fields like email, provider and uid.
+  # config.default_callbacks = true
+
+  # Makes it possible to change the headers names
+  # config.headers_names = {:'access-token' => 'access-token',
+  #                        :'client' => 'client',
+  #                        :'expiry' => 'expiry',
+  #                        :'uid' => 'uid',
+  #                        :'token-type' => 'token-type' }
+
+  # By default, only Bearer Token authentication is implemented out of the box.
+  # If, however, you wish to integrate with legacy Devise authentication, you can
+  # do so by enabling this flag. NOTE: This feature is highly experimental!
+  # config.enable_standard_devise_support = false
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,6 @@
 Rails.application.routes.draw do
   mount_devise_token_auth_for 'User', at: 'api/auth', skip: [:omniauth_callbacks]
   namespace :api do
-    resources :events, only: %i[index show create]
+    resources :events, only: %i[index update create]
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 Rails.application.routes.draw do
-  mount_devise_token_auth_for 'User', at: 'auth'
+  mount_devise_token_auth_for 'User', at: 'api/auth', skip: [:omniauth_callbacks]
   namespace :api do
     resources :events, only: %i[index show create]
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,5 @@
 Rails.application.routes.draw do
+  mount_devise_token_auth_for 'User', at: 'auth'
   namespace :api do
     resources :events, only: %i[index show create]
   end

--- a/db/migrate/20200418112834_devise_token_auth_create_users.rb
+++ b/db/migrate/20200418112834_devise_token_auth_create_users.rb
@@ -1,0 +1,49 @@
+class DeviseTokenAuthCreateUsers < ActiveRecord::Migration[6.0]
+  def change
+    
+    create_table(:users) do |t|
+      ## Required
+      t.string :provider, :null => false, :default => "email"
+      t.string :uid, :null => false, :default => ""
+
+      ## Database authenticatable
+      t.string :encrypted_password, :null => false, :default => ""
+
+      ## Recoverable
+      t.string   :reset_password_token
+      t.datetime :reset_password_sent_at
+      t.boolean  :allow_password_change, :default => false
+
+      ## Rememberable
+      t.datetime :remember_created_at
+
+      ## Confirmable
+      t.string   :confirmation_token
+      t.datetime :confirmed_at
+      t.datetime :confirmation_sent_at
+      t.string   :unconfirmed_email # Only if using reconfirmable
+
+      ## Lockable
+      # t.integer  :failed_attempts, :default => 0, :null => false # Only if lock strategy is :failed_attempts
+      # t.string   :unlock_token # Only if unlock strategy is :email or :both
+      # t.datetime :locked_at
+
+      ## User Info
+      t.string :name
+      t.string :nickname
+      t.string :image
+      t.string :email
+
+      ## Tokens
+      t.json :tokens
+
+      t.timestamps
+    end
+
+    add_index :users, :email,                unique: true
+    add_index :users, [:uid, :provider],     unique: true
+    add_index :users, :reset_password_token, unique: true
+    add_index :users, :confirmation_token,   unique: true
+    # add_index :users, :unlock_token,       unique: true
+  end
+end

--- a/db/migrate/20200418112834_devise_token_auth_create_users.rb
+++ b/db/migrate/20200418112834_devise_token_auth_create_users.rb
@@ -37,6 +37,12 @@ class DeviseTokenAuthCreateUsers < ActiveRecord::Migration[6.0]
       ## Tokens
       t.json :tokens
 
+      t.integer :sign_in_count, default: 0
+      t.datetime :current_sign_in_at
+      t.datetime :last_sign_in_at
+      t.string :current_sign_in_ip
+      t.string :last_sign_in_ip
+      
       t.timestamps
     end
 

--- a/db/migrate/20200418113527_user_has_many_events.rb
+++ b/db/migrate/20200418113527_user_has_many_events.rb
@@ -1,0 +1,5 @@
+class UserHasManyEvents < ActiveRecord::Migration[6.0]
+  def change
+    add_reference :events, :user, foreign_key: true
+  end
+end

--- a/db/migrate/20200418115044_create_attendees.rb
+++ b/db/migrate/20200418115044_create_attendees.rb
@@ -1,0 +1,10 @@
+class CreateAttendees < ActiveRecord::Migration[6.0]
+  def change
+    create_table :attendees do |t|
+      t.references :user, null: false, foreign_key: true
+      t.references :event, null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20200418142805_add_attendee_limit_to_event.rb
+++ b/db/migrate/20200418142805_add_attendee_limit_to_event.rb
@@ -1,0 +1,5 @@
+class AddAttendeeLimitToEvent < ActiveRecord::Migration[6.0]
+  def change
+    add_column :events, :attendee_limit, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -51,11 +51,6 @@ ActiveRecord::Schema.define(version: 2020_04_18_115044) do
     t.string "image"
     t.string "email"
     t.json "tokens"
-    t.integer "sign_in_count", default: 0
-    t.datetime "current_sign_in_at"
-    t.datetime "last_sign_in_at"
-    t.string "current_sign_in_ip"
-    t.string "last_sign_in_ip"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.index ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,10 +10,19 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_04_18_113527) do
+ActiveRecord::Schema.define(version: 2020_04_18_115044) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "attendees", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.bigint "event_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["event_id"], name: "index_attendees_on_event_id"
+    t.index ["user_id"], name: "index_attendees_on_user_id"
+  end
 
   create_table "events", force: :cascade do |t|
     t.string "title"
@@ -42,6 +51,11 @@ ActiveRecord::Schema.define(version: 2020_04_18_113527) do
     t.string "image"
     t.string "email"
     t.json "tokens"
+    t.integer "sign_in_count", default: 0
+    t.datetime "current_sign_in_at"
+    t.datetime "last_sign_in_at"
+    t.string "current_sign_in_ip"
+    t.string "last_sign_in_ip"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.index ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true
@@ -50,5 +64,7 @@ ActiveRecord::Schema.define(version: 2020_04_18_113527) do
     t.index ["uid", "provider"], name: "index_users_on_uid_and_provider", unique: true
   end
 
+  add_foreign_key "attendees", "events"
+  add_foreign_key "attendees", "users"
   add_foreign_key "events", "users"
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_04_12_140620) do
+ActiveRecord::Schema.define(version: 2020_04_18_113527) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -21,6 +21,34 @@ ActiveRecord::Schema.define(version: 2020_04_12_140620) do
     t.integer "category"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.bigint "user_id"
+    t.index ["user_id"], name: "index_events_on_user_id"
   end
 
+  create_table "users", force: :cascade do |t|
+    t.string "provider", default: "email", null: false
+    t.string "uid", default: "", null: false
+    t.string "encrypted_password", default: "", null: false
+    t.string "reset_password_token"
+    t.datetime "reset_password_sent_at"
+    t.boolean "allow_password_change", default: false
+    t.datetime "remember_created_at"
+    t.string "confirmation_token"
+    t.datetime "confirmed_at"
+    t.datetime "confirmation_sent_at"
+    t.string "unconfirmed_email"
+    t.string "name"
+    t.string "nickname"
+    t.string "image"
+    t.string "email"
+    t.json "tokens"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true
+    t.index ["email"], name: "index_users_on_email", unique: true
+    t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
+    t.index ["uid", "provider"], name: "index_users_on_uid_and_provider", unique: true
+  end
+
+  add_foreign_key "events", "users"
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_04_18_115044) do
+ActiveRecord::Schema.define(version: 2020_04_18_142805) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -31,6 +31,7 @@ ActiveRecord::Schema.define(version: 2020_04_18_115044) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.bigint "user_id"
+    t.integer "attendee_limit"
     t.index ["user_id"], name: "index_events_on_user_id"
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -52,6 +52,11 @@ ActiveRecord::Schema.define(version: 2020_04_18_142805) do
     t.string "image"
     t.string "email"
     t.json "tokens"
+    t.integer "sign_in_count", default: 0
+    t.datetime "current_sign_in_at"
+    t.datetime "last_sign_in_at"
+    t.string "current_sign_in_ip"
+    t.string "last_sign_in_ip"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.index ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true

--- a/spec/factories/attendees.rb
+++ b/spec/factories/attendees.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :attendee do
-    user { nil }
-    event { nil }
+    user
+    event
   end
 end

--- a/spec/factories/attendees.rb
+++ b/spec/factories/attendees.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :attendee do
+    user { nil }
+    event { nil }
+  end
+end

--- a/spec/factories/events.rb
+++ b/spec/factories/events.rb
@@ -3,5 +3,6 @@ FactoryBot.define do
     title { 'MyString' }
     description { 'MyString' }
     category { 4 }
+    user
   end
 end

--- a/spec/factories/events.rb
+++ b/spec/factories/events.rb
@@ -4,5 +4,6 @@ FactoryBot.define do
     description { 'MyString' }
     category { 4 }
     user
+    attendee_limit { 30 }
   end
 end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :user do
+    email { "user@mail.com" }
+    password { "MyString" }
+    password_confirmation { "MyString" }
+  end
+end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :user do
-    email { "user@mail.com" }
+    email {|n| "user_#{n}@mail.com" }
     password { "MyString" }
     password_confirmation { "MyString" }
   end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,6 +1,10 @@
 FactoryBot.define do
+  sequence :email do |n|
+    "person#{n}@example.com"
+  end
+
   factory :user do
-    email {|n| "user_#{n}@mail.com" }
+    email { generate :email }
     password { "MyString" }
     password_confirmation { "MyString" }
   end

--- a/spec/models/attendee_spec.rb
+++ b/spec/models/attendee_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Attendee, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/event_spec.rb
+++ b/spec/models/event_spec.rb
@@ -9,11 +9,15 @@ RSpec.describe Event, type: :model do
     it { is_expected.to have_db_column :title }
     it { is_expected.to have_db_column :description }
     it { is_expected.to have_db_column :category }
+    it { is_expected.to have_db_column :attendee_limit }
+
   end
 
   describe 'Validations' do
     it { is_expected.to validate_presence_of :title}
     it { is_expected.to validate_presence_of :description }
     it { is_expected.to validate_presence_of :category }
+    it { is_expected.to validate_presence_of :attendee_limit }
+
   end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -19,4 +19,5 @@ RSpec.configure do |config|
   config.filter_rails_from_backtrace!
   config.include FactoryBot::Syntax::Methods
   config.include(Shoulda::Matchers::ActiveRecord, type: :model)
+  config.include ResponseJSON
 end

--- a/spec/requests/user_can_create_an_event_spec.rb
+++ b/spec/requests/user_can_create_an_event_spec.rb
@@ -10,7 +10,9 @@ RSpec.describe 'POST /events', type: :request do
         event: {
           title: 'I Just Created This',
           description: 'I dont want anyone to join this event',
-          category: 'casual'
+          category: 'casual',
+          user_id: user.id,
+          attendee_limit: 4
         }
       },
       headers: user_headers

--- a/spec/requests/user_can_create_an_event_spec.rb
+++ b/spec/requests/user_can_create_an_event_spec.rb
@@ -1,15 +1,19 @@
 RSpec.describe 'POST /events', type: :request do
+  let(:user) { create(:user) }
+  let(:user_credentials) { user.create_new_auth_token }
+  let(:user_headers) { { HTTP_ACCEPT: "application/json" }.merge!(user_credentials) }
   describe 'POST /events' do
 
     before do
       post '/api/events',
-        params: {
-          event: {
-            title: 'I Just Created This',
-            description: 'I dont want anyone to join this event',
-            category: 'casual'
-          }
+      params: {
+        event: {
+          title: 'I Just Created This',
+          description: 'I dont want anyone to join this event',
+          category: 'casual'
         }
+      },
+      headers: user_headers
     end
     
     it 'should return a 200 response' do 
@@ -30,7 +34,8 @@ RSpec.describe 'POST /events', type: :request do
           description: 'I dont want anyone to join this event',
           category: 'casual'
         }
-      }
+      },
+      headers: user_headers
     end
 
     it 'event is missing an attribute' do

--- a/spec/requests/user_can_create_an_event_spec.rb
+++ b/spec/requests/user_can_create_an_event_spec.rb
@@ -2,6 +2,7 @@ RSpec.describe 'POST /events', type: :request do
   let(:user) { create(:user) }
   let(:user_credentials) { user.create_new_auth_token }
   let(:user_headers) { { HTTP_ACCEPT: "application/json" }.merge!(user_credentials) }
+  
   describe 'POST /events' do
 
     before do

--- a/spec/requests/user_can_create_an_event_spec.rb
+++ b/spec/requests/user_can_create_an_event_spec.rb
@@ -3,8 +3,7 @@ RSpec.describe 'POST /events', type: :request do
   let(:user_credentials) { user.create_new_auth_token }
   let(:user_headers) { { HTTP_ACCEPT: "application/json" }.merge!(user_credentials) }
   
-  describe 'POST /events' do
-
+  describe 'POST /api/events' do
     before do
       post '/api/events',
       params: {

--- a/spec/requests/user_can_join_an_event_spec.rb
+++ b/spec/requests/user_can_join_an_event_spec.rb
@@ -61,7 +61,7 @@ RSpec.describe 'PUT /api/events/:id', type: :request do
       end
 
       it 'returns error message' do 
-        expect(response_json['error_message']).to eq "We are experiencing internal errors. Please refresh the page and contact support. Couldn't find Event with 'id'={:id=>\"99\"}"
+        expect(response_json['error_message']).to eq "We are experiencing internal errors. Please refresh the page and contact support. Couldn't find Event with 'id'=99"
       end
     end
   end

--- a/spec/requests/user_can_join_an_event_spec.rb
+++ b/spec/requests/user_can_join_an_event_spec.rb
@@ -1,7 +1,7 @@
-RSpec.describe 'PUT /events', type: :request do
+RSpec.describe 'PUT /api/events/:id', type: :request do
   let(:event_creator) { create(:user) }
-  let(:event) { create(:event, user: event_creator)}
-  let!(:other_attendees) { 4.times { create(:attendee, event: event) } }
+  let(:event) { create(:event, attendee_limit: 20, user: event_creator)}
+
   let(:attendee) { create(:user, email: 'attendee@mail.com') }
   let(:user_credentials) { attendee.create_new_auth_token }
   let(:user_headers) { { HTTP_ACCEPT: "application/json" }.merge!(user_credentials) }
@@ -10,11 +10,61 @@ RSpec.describe 'PUT /events', type: :request do
     before do
       put "/api/events/#{event.id}", headers: user_headers
     end
-    it 'returns 200 response' do 
+
+    it 'returns 200 response status' do 
       expect(response.status).to eq 200
     end
+  
     it 'returns success message' do 
+      binding.pry
       expect(response_json['message']).to eq 'You are on the guest list!'
     end
   end
-end 
+
+  describe 'unsuccessfull when' do
+    describe 'user is not authenticated' do 
+      before do
+        put "/api/events/#{event.id}"
+      end
+
+      it 'returns 401 response status' do
+        expect(response.status).to eq 401
+      end
+
+      it 'returns error message' do 
+        expect(response_json['errors'].first).to eq 'You need to sign in or sign up before continuing.'
+      end
+    end
+
+    describe 'event attendee limit is reached' do
+      let!(:other_attendees) { 20.times { create(:attendee, event: event) } }
+
+      before do 
+        put "/api/events/#{event.id}", headers: user_headers
+      end
+
+      it 'returns 400 response status' do
+        expect(response.status).to eq 400
+      end
+
+      it 'returns error message' do 
+        expect(response_json['error_message']).to eq "Guest list is full..."
+      end
+    end
+
+    describe 'event attendee limit is reached' do
+      before do 
+        put "/api/events/99", headers: user_headers
+      end
+
+      it 'returns 400 response status' do
+        expect(response.status).to eq 400
+      end
+
+      it 'returns error message' do 
+        expect(response_json['error_message']).to eq  "We are experiencing internal errors. Please refresh the page and contact support. Couldn't find Event with 'id'={:id=>\"99\"}"
+      end
+
+    end
+  end
+end

--- a/spec/requests/user_can_join_an_event_spec.rb
+++ b/spec/requests/user_can_join_an_event_spec.rb
@@ -1,0 +1,20 @@
+RSpec.describe 'PUT /events', type: :request do
+  let(:event_creator) { create(:user) }
+  let(:event) { create(:event, user: event_creator)}
+  let!(:other_attendees) { 4.times { create(:attendee, event: event) } }
+  let(:attendee) { create(:user, email: 'attendee@mail.com') }
+  let(:user_credentials) { attendee.create_new_auth_token }
+  let(:user_headers) { { HTTP_ACCEPT: "application/json" }.merge!(user_credentials) }
+  
+  describe 'User can attend event successfully' do
+    before do
+      put "/api/events/#{event.id}", headers: user_headers
+    end
+    it 'returns 200 response' do 
+      expect(response.status).to eq 200
+    end
+    it 'returns success message' do 
+      expect(response_json['message']).to eq 'You are on the guest list!'
+    end
+  end
+end 

--- a/spec/requests/user_can_join_an_event_spec.rb
+++ b/spec/requests/user_can_join_an_event_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe 'PUT /api/events/:id', type: :request do
   let(:attendee) { create(:user, email: 'attendee@mail.com') }
   let(:user_credentials) { attendee.create_new_auth_token }
   let(:user_headers) { { HTTP_ACCEPT: "application/json" }.merge!(user_credentials) }
-  
+
   describe 'User can attend event successfully' do
     before do
       put "/api/events/#{event.id}", headers: user_headers
@@ -14,15 +14,14 @@ RSpec.describe 'PUT /api/events/:id', type: :request do
     it 'returns 200 response status' do 
       expect(response.status).to eq 200
     end
-  
+
     it 'returns success message' do 
-      binding.pry
       expect(response_json['message']).to eq 'You are on the guest list!'
     end
   end
 
   describe 'unsuccessfull when' do
-    describe 'user is not authenticated' do 
+    describe 'user is not authenticated' do
       before do
         put "/api/events/#{event.id}"
       end
@@ -32,10 +31,10 @@ RSpec.describe 'PUT /api/events/:id', type: :request do
       end
 
       it 'returns error message' do 
-        expect(response_json['errors'].first).to eq 'You need to sign in or sign up before continuing.'
+        expect(response_json['errors'].first).to eq "You need to sign in or sign up before continuing."
       end
     end
-
+    
     describe 'event attendee limit is reached' do
       let!(:other_attendees) { 20.times { create(:attendee, event: event) } }
 
@@ -62,9 +61,8 @@ RSpec.describe 'PUT /api/events/:id', type: :request do
       end
 
       it 'returns error message' do 
-        expect(response_json['error_message']).to eq  "We are experiencing internal errors. Please refresh the page and contact support. Couldn't find Event with 'id'={:id=>\"99\"}"
+        expect(response_json['error_message']).to eq "We are experiencing internal errors. Please refresh the page and contact support. Couldn't find Event with 'id'={:id=>\"99\"}"
       end
-
     end
   end
 end

--- a/spec/requests/user_can_see_all_events_spec.rb
+++ b/spec/requests/user_can_see_all_events_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe 'GET /api/events', type: :request do
+RSpec.describe 'GET /events', type: :request do
   describe 'GET /api/events' do
     let!(:event_1) { create(:event, title: "Join me") }
     let!(:event_2) { create(:event, title: "Come play soccer") }

--- a/spec/requests/user_can_view_specific_event_details_spec.rb
+++ b/spec/requests/user_can_view_specific_event_details_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe 'GET /api/events', type: :request do
         title: 'Celebrate easter with me!',
         description: 'Kevin is not allowed to come. Complete buzzkill',
         category: 'casual')
-      get "/api/events/#{@event.id}"
+      get "/api/events/"
     end
 
     it 'should return a valid event response' do

--- a/spec/support/response_json.rb
+++ b/spec/support/response_json.rb
@@ -1,0 +1,5 @@
+module ResponseJSON
+  def response_json
+    JSON.parse(response.body)
+  end
+end 


### PR DESCRIPTION
# [PT Story](https://www.pivotaltracker.com/story/show/172354569)
```
As an API
In order to let users partake in an event
I need to provide an join/leave functionality
```
## Changes proposed in this pull request:
* Adds functionality for a user to own an event and an attendee to be added to events
* Adds attendee limit option for events
## What I have learned working on this feature:
* Add ALL the params of an event into a test that lists the params
* The process of having user join events